### PR TITLE
bump gnome runtime to v46

### DIFF
--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -41,8 +41,8 @@ modules:
       - "-Ddocs=false"
     sources:
       - type: archive
-        url: https://github.com/flatpak/libportal/releases/download/0.5/libportal-0.5.tar.xz
-        sha256: d8c8cb18a34e5eeb26a39c94044c955995b01de0e139caac5e18c076cf821b3b
+        url: https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz
+        sha256: 297b90b263fad22190a26b8c7e8ea938fe6b18fb936265e588927179920d3805
 
   - name: com.github.rajsolai.textsnatcher
     buildsystem: meson

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -38,12 +38,12 @@ modules:
     builddir: true
     config-opts:
       - "--libdir=/app/lib"
-      - "--buildtype=debugoptimized",
+      - "--buildtype=debugoptimized"
       - "-Dintrospection=false"
-      - "-Dbackend-gtk3=enabled",
-      - "-Dbackend-gtk4=disabled",
-      - "-Dbackend-qt5=disabled",
-      - "-Ddocs=false",
+      - "-Dbackend-gtk3=enabled"
+      - "-Dbackend-gtk4=disabled"
+      - "-Dbackend-qt5=disabled"
+      - "-Ddocs=false"
       - "-Dtests=false"
     sources:
       - type: archive

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -39,6 +39,7 @@ modules:
     config-opts:
       - "-Dbackend-gtk3=enabled"
       - "-Ddocs=false"
+      - "-Dintrospection=false"
     sources:
       - type: archive
         url: https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -37,7 +37,7 @@ modules:
     buildsystem: meson
     builddir: true
     config-opts:
-      - "-Dbackends=gtk3"
+      - "-Dbackend-gtk3=enabled"
       - "-Ddocs=false"
     sources:
       - type: archive

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -1,7 +1,7 @@
 app-id: com.github.rajsolai.textsnatcher
 
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 base: io.elementary.BaseApp
 base-version: "juno-22.08"
 sdk: org.gnome.Sdk

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -37,10 +37,14 @@ modules:
     buildsystem: meson
     builddir: true
     config-opts:
-      - "-Dbackend-gtk3=enabled"
-      - "-Ddocs=false"
+      - "--libdir=/app/lib"
+      - "--buildtype=debugoptimized",
       - "-Dintrospection=false"
-      - "-Dvapi=false"
+      - "-Dbackend-gtk3=enabled",
+      - "-Dbackend-gtk4=disabled",
+      - "-Dbackend-qt5=disabled",
+      - "-Ddocs=false",
+      - "-Dtests=false"
     sources:
       - type: archive
         url: https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz

--- a/com.github.rajsolai.textsnatcher.yml
+++ b/com.github.rajsolai.textsnatcher.yml
@@ -40,6 +40,7 @@ modules:
       - "-Dbackend-gtk3=enabled"
       - "-Ddocs=false"
       - "-Dintrospection=false"
+      - "-Dvapi=false"
     sources:
       - type: archive
         url: https://github.com/flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024.